### PR TITLE
Retain pathname when navigating to catalog

### DIFF
--- a/src/components/useWindowLocation.tsx
+++ b/src/components/useWindowLocation.tsx
@@ -57,9 +57,9 @@ export function useSearchParams(): [URLSearchParams, (setSearchParams: URLSearch
         (searchParams: URLSearchParams) => {
             const newSearch = searchParams.toString()
             if (newSearch) history.update('?' + newSearch)
-            else history.update(pathname)   // retain the existing pathname
+            else history.update(pathname) // retain the existing pathname
         },
-        [history]
+        [history, pathname]
     )
     return [searchParams, setSearchParams]
 }

--- a/src/components/useWindowLocation.tsx
+++ b/src/components/useWindowLocation.tsx
@@ -51,12 +51,13 @@ export function useWindowHistory() {
 
 export function useSearchParams(): [URLSearchParams, (setSearchParams: URLSearchParams) => void] {
     const history = useWindowHistory()
+    const pathname = history.location?.pathname || '/'
     const searchParams = useMemo<URLSearchParams>(() => new URLSearchParams(history.location?.search ?? '/'), [history.location?.search])
     const setSearchParams = useCallback(
         (searchParams: URLSearchParams) => {
             const newSearch = searchParams.toString()
             if (newSearch) history.update('?' + newSearch)
-            else history.update('/')
+            else history.update(pathname)   // retain the existing pathname
         },
         [history]
     )


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Trying to fix this issue where the pathname disappears when navigating to the catalog:
![image](https://user-images.githubusercontent.com/38960034/179099850-9f2e141e-6bf0-4003-abfa-497cd4f77599.png)

- Add existing pathname when updating the window location

I'm not too familiar with this code, but maybe we need to retain the pathname in the first if condition as well? https://github.com/stolostron/react-data-view/blob/bc6937ac832316cf548c1ccf7d8a0df53ba4c19c/src/components/useWindowLocation.tsx#L58