### PR TITLE
Allow additional content for catalog card.

### DIFF
--- a/src/CatalogCard.tsx
+++ b/src/CatalogCard.tsx
@@ -57,6 +57,7 @@ export interface ICatalogCard {
     badge?: string
     badgeColor?: CatalogColor
     onClick?: () => void
+    additionalContent?: React.ReactNode
 }
 
 export interface ICatalogCardFeatureGroup {
@@ -156,8 +157,8 @@ export function CatalogCard<T extends object>(props: {
             style={{
                 transition: 'box-shadow 0.25s',
                 cursor: card.onClick ? 'pointer' : undefined,
-                opacity: card.onClick ? undefined : '0.5',
             }}
+            isDisabledRaised={!card.onClick}
         >
             <CardHeader>
                 <Split hasGutter style={{ width: '100%' }}>
@@ -262,6 +263,7 @@ export function CatalogCard<T extends object>(props: {
                     </div>
                 </CardFooter>
             )}
+            {card.additionalContent}
         </Card>
     )
 }


### PR DESCRIPTION
This PR adds additional props/updates styles to be able to implement https://github.com/stolostron/console/pull/1866

I've removed the custom `opacity` styling as it makes the card content hard to read. Instead of the custom styling Im using PF's `isDisabledRaised`

Unfortunately since this library does not make use of JSX composition, adding any custom elements is very hard. In order to add the Alert (as is in [the design](https://user-images.githubusercontent.com/2078045/180164286-4f3b310c-e93c-4bf2-8fc2-0dab0e56828c.png) ) I had to add additional prop

Signed-off-by: Rastislav Wagner <rawagner@redhat.com>