### PR TITLE
Add reactnode support to ICatalogCardListItem text

### DIFF
--- a/src/CatalogCard.tsx
+++ b/src/CatalogCard.tsx
@@ -96,7 +96,7 @@ export enum CatalogCardListItemIcon {
 
 export interface ICatalogCardListItem {
     icon?: ReactNode
-    text: string
+    text: string | ReactNode
 }
 
 export type CatalogCardItem = ICatalogCardDescription | ICatalogCardList


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

- Add reactnode support to ICatalogCardListItem text so we can have tooltips

![image](https://user-images.githubusercontent.com/38960034/180851379-5210539a-756d-4cfa-85ba-eeace6cf06ba.png)
