### PR TITLE
Support card item popup help

### DIFF
--- a/demo/ControlPlane.tsx
+++ b/demo/ControlPlane.tsx
@@ -27,7 +27,7 @@ export function ControlPlane() {
                         title: 'Features',
                         icon: <CheckIcon color={getPatternflyColor(PatternFlyColor.Green)} />,
                         items: [
-                            { text: 'Better hardware utilization' },
+                            { text: 'Better hardware utilization', help: { text: 'Popover example' } },
                             { text: 'Network and trusted segmentation between control plane and workers' },
                             { text: 'Rapid cluster creation' },
                         ],
@@ -87,6 +87,7 @@ export function ControlPlane() {
         <Fragment>
             <PageHeader
                 title="Control Plane"
+                titleHelp={{ text: 'Example popup help' }}
                 description="Next, select a control plane type for your on-premise machine."
                 breadcrumbs={breadcrumbs}
             />

--- a/src/CatalogCard.tsx
+++ b/src/CatalogCard.tsx
@@ -18,6 +18,7 @@ import {
     LabelGroup,
     List,
     ListItem,
+    Popover,
     Split,
     SplitItem,
     Stack,
@@ -25,7 +26,7 @@ import {
     Title,
     Truncate,
 } from '@patternfly/react-core'
-import { ExternalLinkAltIcon } from '@patternfly/react-icons'
+import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons'
 import { ReactNode, useCallback, useMemo, useState } from 'react'
 import { IconWrapper } from './components/IconWrapper'
 import { Scrollable } from './components/Scrollable'
@@ -96,6 +97,12 @@ export enum CatalogCardListItemIcon {
 
 export interface ICatalogCardListItem {
     icon?: ReactNode
+    text: string
+    help?: ICatalogPopover
+}
+
+export interface ICatalogPopover {
+    title?: string
     text: string
 }
 
@@ -314,6 +321,24 @@ export function CardList(props: { title: string; icon?: ReactNode; items: ICatal
                     return (
                         <ListItem key={index} icon={itemIcon} style={{ opacity: 0.85 }}>
                             {listItem.text}
+
+                            {listItem.help && (
+                                // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+                                <div onClick={(e) => e.stopPropagation()}>
+                                    <Popover headerContent={listItem.help.title} bodyContent={listItem.help.text}>
+                                        <Button
+                                            variant="link"
+                                            style={{
+                                                padding: 0,
+                                                marginLeft: '8px',
+                                                verticalAlign: 'middle',
+                                            }}
+                                        >
+                                            <OutlinedQuestionCircleIcon />
+                                        </Button>
+                                    </Popover>
+                                </div>
+                            )}
                         </ListItem>
                     )
                 })}

--- a/src/PageHeader.tsx
+++ b/src/PageHeader.tsx
@@ -108,28 +108,3 @@ export function PageHeader(props: {
         </div>
     )
 }
-
-{
-    /* <TextContent>
-                                                    <Title headingLevel="h1">
-                                                        {props.title}
-                                                        {props.titleTooltip && (
-                                                            <Popover
-                                                                bodyContent={props.titleTooltip}
-                                                              
-                                                            >
-                                                                <Button
-                                                                    variant="link"
-                                                                    style={{
-                                                                        padding: 0,
-                                                                        marginLeft: '8px',
-                                                                        verticalAlign: 'middle',
-                                                                    }}
-                                                                >
-                                                                    <OutlinedQuestionCircleIcon />
-                                                                </Button>
-                                                            </Popover>
-                                                        )}
-                                                    </Title>
-                                                </TextContent> */
-}

--- a/src/PageHeader.tsx
+++ b/src/PageHeader.tsx
@@ -1,6 +1,8 @@
-import { Breadcrumb, BreadcrumbItem, PageSection, Split, SplitItem, Text, Title } from '@patternfly/react-core'
+import { Breadcrumb, BreadcrumbItem, Button, PageSection, Popover, Split, SplitItem, Text, Title } from '@patternfly/react-core'
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons'
 import { Fragment, ReactNode } from 'react'
 import { useHistory } from 'react-router-dom'
+import { ICatalogPopover } from './CatalogCard'
 import { useWindowSizeOrLarger, WindowSize } from './components/useBreakPoint'
 import { ThemeE, useTheme } from './Theme'
 
@@ -40,6 +42,7 @@ function Breadcrumbs(props: { breadcrumbs: ICatalogBreadcrumb[] }) {
 export function PageHeader(props: {
     breadcrumbs?: ICatalogBreadcrumb[]
     title?: string
+    titleHelp?: ICatalogPopover
     description?: string
     navigation?: ReactNode
     actions?: ReactNode
@@ -66,7 +69,25 @@ export function PageHeader(props: {
                                     <Breadcrumbs breadcrumbs={breadcrumbs} />
                                 </div>
                             )}
-                            {title && <Title headingLevel="h1">{title}</Title>}
+                            {title && (
+                                <Title headingLevel="h1">
+                                    {title}
+                                    {props.titleHelp && (
+                                        <Popover headerContent={props.titleHelp.title} bodyContent={props.titleHelp.text}>
+                                            <Button
+                                                variant="link"
+                                                style={{
+                                                    padding: 0,
+                                                    marginLeft: '8px',
+                                                    verticalAlign: 'middle',
+                                                }}
+                                            >
+                                                <OutlinedQuestionCircleIcon />
+                                            </Button>
+                                        </Popover>
+                                    )}
+                                </Title>
+                            )}
                             {description && (
                                 <Text component="p" style={{ opacity: 0.85, paddingTop: 2 }}>
                                     {description}
@@ -86,4 +107,29 @@ export function PageHeader(props: {
             </Split>
         </div>
     )
+}
+
+{
+    /* <TextContent>
+                                                    <Title headingLevel="h1">
+                                                        {props.title}
+                                                        {props.titleTooltip && (
+                                                            <Popover
+                                                                bodyContent={props.titleTooltip}
+                                                              
+                                                            >
+                                                                <Button
+                                                                    variant="link"
+                                                                    style={{
+                                                                        padding: 0,
+                                                                        marginLeft: '8px',
+                                                                        verticalAlign: 'middle',
+                                                                    }}
+                                                                >
+                                                                    <OutlinedQuestionCircleIcon />
+                                                                </Button>
+                                                            </Popover>
+                                                        )}
+                                                    </Title>
+                                                </TextContent> */
 }


### PR DESCRIPTION
Signed-off-by: James Talton <jtalton@redhat.com>

```
export interface ICatalogCardListItem {
    icon?: ReactNode
    text: string
    help?: ICatalogPopover
}

export interface ICatalogPopover {
    title?: string
    text: string
}
```
![Screen Shot 2022-07-25 at 3 55 22 PM](https://user-images.githubusercontent.com/6277895/180863337-7eff38c9-c38b-404b-9775-022e067919c6.png)

