### PR TITLE
Remove truncate from label

### DIFF
--- a/src/CatalogCard.tsx
+++ b/src/CatalogCard.tsx
@@ -28,7 +28,6 @@ import {
     Stack,
     StackItem,
     Title,
-    Truncate,
 } from '@patternfly/react-core'
 import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons'
 import { Fragment, ReactNode, useCallback, useMemo, useState } from 'react'
@@ -282,7 +281,7 @@ export function CatalogCard<T extends object>(props: {
                                 <LabelGroup>
                                     {card.labels.map((item) => (
                                         <Label key={item.label} color={item.color}>
-                                            <Truncate content={item.label} style={{ minWidth: 0 }} />
+                                            {item.label}
                                         </Label>
                                     ))}
                                 </LabelGroup>


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Bugzilla: https://github.com/stolostron/backlog/issues/24548

- Remove truncate from label to fix the crash when running only in MCE

Looks like Truncate is not available in OCP 4.10, I'm guessing because it's still in beta(sorry about the image, the screenshot feature in MacOS wasn't able to capture the value):
![unnamed](https://user-images.githubusercontent.com/38960034/181797696-68666697-8bf0-4b54-b51a-8299bc34080f.jpg)

