### PR TITLE
ACM-31597 Lock down v3.4.z to patch-only updates

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,10 +1,5 @@
 name: NPM Publish
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - src/**
     workflow_dispatch:
         inputs:
             versionIncrement:
@@ -13,8 +8,6 @@ on:
                 default: minor
                 type: choice
                 options:
-                    - major
-                    - minor
                     - patch
 jobs:
     npm-publish:
@@ -40,12 +33,6 @@ jobs:
                   default_author: github_actions
                   message: Release ${{ env.TAG }} [skip ci]
                   tag: ${{ env.TAG }}
-            - run: npm publish
+            - run: npm publish --tag ${GITHUB_REF##*/}
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-            - run: npm run pages
-            - uses: JamesIves/github-pages-deploy-action@4.1.5
-              with:
-                  branch: gh-pages
-                  folder: dist
-                  single-commit: true


### PR DESCRIPTION
## Summary
- Cherry-pick lockdown commit from v3.3.z to restrict v3.4.z to patch-only npm updates
- Removes major/minor version increment options from publish workflow
- Tags npm publishes with the branch name instead of latest

Part of the ACM 5.0 / MCE 5.0 release cutover ([ACM-31597](https://redhat.atlassian.net/browse/ACM-31597)).

[ACM-31597]: https://redhat.atlassian.net/browse/ACM-31597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ